### PR TITLE
Add pnpm setup to CI workflows for frontend and backend

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 10.5.2
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 10.5.2
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This pull request includes updates to the CI configuration for both backend and frontend workflows to ensure consistency in package management. The most important changes include the addition of steps to install `pnpm` in the respective workflow files.

CI configuration updates:

* [`.github/workflows/ci-backend.yml`](diffhunk://#diff-d534d457d2f453ff292b326309bebf3d6b2f7e067ca4247038b61df22d09c728R22-R27): Added a step to install `pnpm` version 10.5.2 without running the install command.
* [`.github/workflows/ci-frontend.yml`](diffhunk://#diff-eb2db7207db87402040437448325e7fc06061106100926394b2d495548d35c6aR22-R27): Added a step to install `pnpm` version 10.5.2 without running the install command.