### PR TITLE
CI: Remove path filters for frontend and backend in push and pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,7 @@ name: CI
 
 on:
   push:
-    paths:
-      - 'frontend/**'
-      - 'backend/**'
   pull_request:
-    paths:
-      - 'frontend/**'
-      - 'backend/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request modifies the CI workflow configuration by removing path filters for `push` and `pull_request` events. This change ensures that the CI workflow runs for all changes, regardless of the file paths affected